### PR TITLE
fix f-string issue

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -94,7 +94,7 @@ def main() -> None:
         # 終了ノードの場合
         if agent.is_end_node(thread):
             selected_copy = agent.get_state_value(thread, "selected_copy")
-            st.success(f"生成したコピー: {selected_copy["copy_text"]}")
+            st.success(f'生成したコピー: {selected_copy["copy_text"]}')
             break
 
 


### PR DESCRIPTION
手元で動作させようとしたところ、以下のエラーが生じました。

```bash
File "streamlit-langgraph-HITL-copy-generator/src/app.py", line 97
              st.success(f"生成したコピー: {selected_copy["copy_text"]}")
                                                    ^
SyntaxError: f-string: unmatched '['
```